### PR TITLE
Feat/roll initiative

### DIFF
--- a/src/combat.mjs
+++ b/src/combat.mjs
@@ -10,7 +10,6 @@ export function set_combat_hooks() {
     Hooks.on("combatStart", async (combat, updateData) => {
         const roundRender = parseCombatRound({ ...combat, ...updateData })
         const turnRender = parseTurn(combat, updateData) 
-        Logger.info(turnRender)
         socket.emit('combat', roundRender+turnRender)
     })
     Hooks.on("combatTurn", async (combat, updateData, updateOptions) => {
@@ -22,7 +21,6 @@ export function set_combat_hooks() {
         if (updateOptions.direction < 1) return
         const roundRender = parseCombatRound({ ...combat, ...updateData }, updateOptions)
         const turnRender = parseTurn(combat, updateData) 
-        Logger.info(turnRender)
         socket.emit('combat', roundRender+turnRender)
     })
 }
@@ -49,15 +47,12 @@ function parseTurn(combat, updateData) {
     const discordId = actor_to_discord_ids(actor)
     const healthSetting = game.settings.get(MODULE_ID, COMBAT_HEALTH_ESTIMATE)
 
-    Logger.info("before")
     let output = ''
     if(discordId.length)
         output += `It's your turn <@${discordId[0]}>\n`
     output += '```md\n'
     output += `# Initiative ${actor.initiative} Round ${c.round}\n`
 
-    Logger.info("1")
-    Logger.info(output)
     if(turn.defeated) {
         output += `${actor.name} <Defeated>\n`
     } else if (token.document.hidden) {
@@ -72,8 +67,6 @@ function parseTurn(combat, updateData) {
         output += getEffectsInMarkdown(actor, token)
     }
     output += '```\n'
-    Logger.info("final")
-    Logger.info(output)
     return output
 }
 

--- a/src/combat.mjs
+++ b/src/combat.mjs
@@ -26,8 +26,16 @@ export function set_combat_hooks() {
 }
 
 function getEffectsInMarkdown(actor, token) {
+    // Merge Actor effects and token.delta effects
+    let effects = new Map()
+    actor.effects.forEach((v, k) => {
+        if (!effects.has(v._id)) effects.set(v._id,v)
+    })
+    token.document.delta.effects.forEach((v, k) => {
+        if (!effects.has(v._id)) effects.set(v._id,v)
+    })
+
     let markdown = ''
-    const effects = (token.actorlink) ? actor.effects : token.document.delta.effects
     effects.forEach(val => {
         markdown += `${'-'.padStart(4)} ${val.name}\n`
     })
@@ -46,6 +54,9 @@ function parseTurn(combat, updateData) {
     const token = canvas.tokens.placeables.find(p => p.id === turn.tokenId)
     const discordId = actor_to_discord_ids(actor)
     const healthSetting = game.settings.get(MODULE_ID, COMBAT_HEALTH_ESTIMATE)
+
+    Logger.info(actor)
+    Logger.info(token)
 
     let output = ''
     if(discordId.length)

--- a/src/combat.mjs
+++ b/src/combat.mjs
@@ -10,6 +10,7 @@ export function set_combat_hooks() {
     Hooks.on("combatStart", async (combat, updateData) => {
         const roundRender = parseCombatRound({ ...combat, ...updateData })
         const turnRender = parseTurn(combat, updateData) 
+        Logger.info(turnRender)
         socket.emit('combat', roundRender+turnRender)
     })
     Hooks.on("combatTurn", async (combat, updateData, updateOptions) => {
@@ -21,6 +22,7 @@ export function set_combat_hooks() {
         if (updateOptions.direction < 1) return
         const roundRender = parseCombatRound({ ...combat, ...updateData }, updateOptions)
         const turnRender = parseTurn(combat, updateData) 
+        Logger.info(turnRender)
         socket.emit('combat', roundRender+turnRender)
     })
 }
@@ -41,17 +43,21 @@ function parseTurn(combat, updateData) {
         game.actors.find(a => a.id === turn.actorId), 
         combat.combatants.find(cb => cb.tokenId === turn.tokenId))
 
-    if (actor.hidden) return
+    if (actor.hidden) return ''
 
     const token = canvas.tokens.placeables.find(p => p.id == turn.tokenId)
     const discordId = actor_to_discord_ids(actor)
     const healthSetting = game.settings.get(MODULE_ID, COMBAT_HEALTH_ESTIMATE)
 
+    Logger.info("before")
     let output = ''
     if(discordId.length)
         output += `It's your turn <@${discordId[0]}>\n`
     output += '```md\n'
     output += `# Initiative ${actor.initiative} Round ${c.round}\n`
+
+    Logger.info("1")
+    Logger.info(output)
     if(turn.defeated) {
         output += `${actor.name} <Defeated>\n`
     } else if (token.document.hidden) {
@@ -66,6 +72,8 @@ function parseTurn(combat, updateData) {
         output += getEffectsInMarkdown(actor, token)
     }
     output += '```\n'
+    Logger.info("final")
+    Logger.info(output)
     return output
 }
 

--- a/src/combat.mjs
+++ b/src/combat.mjs
@@ -26,9 +26,7 @@ export function set_combat_hooks() {
 }
 
 function getEffectsInMarkdown(actor, token) {
-    // Merge Actor effects and token.delta effects
     let effects = new Map()
-    Logger.info(token)
     if (token.document.actorLink) {
         for(const e of actor.allApplicableEffects()) {
             if (e.disabled) continue

--- a/src/combat.mjs
+++ b/src/combat.mjs
@@ -26,25 +26,20 @@ export function set_combat_hooks() {
 }
 
 function getEffectsInMarkdown(actor, token) {
-    let effects = new Map()
-    if (token.document.actorLink) {
-        for(const e of actor.allApplicableEffects()) {
-            if (e.disabled) continue
-            // Ignore passive effects without attached statuses
-            if (e.duration.type === 'none' && e.statuses.size === 0) continue
-            if (!effects.has(e._id)) effects.set(e._id,e.name)
+    let a = (token.document.actorLink) ? actor : token.actor
+
+    let addedEffects = new Map()
+    let markdown = ''
+    for(const e of a.allApplicableEffects()) {
+        if (e.disabled) continue
+        // Ignore passive effects without attached statuses
+        if (e.duration.type === 'none' && e.statuses.size === 0) continue
+        if (!addedEffects.has(e._id)) {
+            markdown += `${'-'.padStart(4)} ${e.name}\n`
+            addedEffects.set(e._id,e.name)
         }
     }
-    else {
-        token.document.delta.effects.forEach((v) => {
-            if (!effects.has(v._id)) effects.set(v._id,v.name)
-        })
-    }
 
-    let markdown = ''
-    effects.forEach(val => {
-        markdown += `${'-'.padStart(4)} ${val}\n`
-    })
     return markdown
 }
 

--- a/src/combat.mjs
+++ b/src/combat.mjs
@@ -43,7 +43,7 @@ function parseTurn(combat, updateData) {
 
     if (actor.hidden) return ''
 
-    const token = canvas.tokens.placeables.find(p => p.id == turn.tokenId)
+    const token = canvas.tokens.placeables.find(p => p.id === turn.tokenId)
     const discordId = actor_to_discord_ids(actor)
     const healthSetting = game.settings.get(MODULE_ID, COMBAT_HEALTH_ESTIMATE)
 
@@ -77,7 +77,7 @@ function parseCombatRound(combat) {
             ...c, 
             ix: c._id, 
             actor: game.actors.find(a => a.id === c.actorId), 
-            token: canvas.tokens.placeables.find(p => p.id == c.tokenId) 
+            token: canvas.tokens.placeables.find(p => p.id === c.tokenId) 
         }
     })
     const healthSetting = game.settings.get(MODULE_ID, COMBAT_HEALTH_ESTIMATE)

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -9,6 +9,12 @@ export const MODULE_DEBUG_TAG = [
 export const AUTH = "auth"
 export const ORONDER_CONFIGURATION_FORM = "oronder_options"
 export const ID_MAP = "id_map"
+export const COMBAT_HEALTH_ESTIMATE = 'combat_health_estimate'
+export const COMBAT_HEALTH_ESTIMATE_TYPE = Object.freeze({
+    'Monsters Only': 0,
+    'All': 1,
+    'None': 2
+})
 export const ACTORS = `${MODULE_ID}.actors`
 const dev_mode = window.location.host === 'localhost:65434'
 const url_common = dev_mode ? '://localhost:65435' : 's://api.oronder.com'

--- a/src/module.mjs
+++ b/src/module.mjs
@@ -29,7 +29,6 @@ Hooks.once("ready", async () => {
     if (game.user.isGM) {
         await registerSettings()
         open_socket_with_oronder()
-        set_combat_hooks()
     }
 
     game.socket.on(SOCKET_NAME, data => {

--- a/src/module.mjs
+++ b/src/module.mjs
@@ -98,6 +98,7 @@ export function open_socket_with_oronder(update = false) {
 
     monks_token_bar_hooks()
     handle_incoming_rolls()
+    set_combat_hooks()
 }
 
 

--- a/src/settings-form-application.mjs
+++ b/src/settings-form-application.mjs
@@ -1,5 +1,15 @@
 import {Logger} from "./util.mjs"
-import {AUTH, DAYS_OF_WEEK, DISCORD_INIT_LINK, ID_MAP, MODULE_ID, ORONDER_BASE_URL, TIMEZONES} from "./constants.mjs"
+import {
+    AUTH, 
+    COMBAT_HEALTH_ESTIMATE,
+    COMBAT_HEALTH_ESTIMATE_TYPE,
+    DAYS_OF_WEEK,
+    DISCORD_INIT_LINK,
+    ID_MAP,
+    MODULE_ID,
+    ORONDER_BASE_URL,
+    TIMEZONES
+} from "./constants.mjs"
 import {full_sync, sync_actor} from "./sync.mjs"
 import {open_socket_with_oronder} from "./module.mjs"
 
@@ -15,6 +25,8 @@ export class OronderSettingsFormApplication extends FormApplication {
             init_active: false,
             show_advanced: false,
             id_map: id_map,
+            combat_health_estimate: game.settings.get(MODULE_ID, COMBAT_HEALTH_ESTIMATE),
+            combat_health_estimate_type: COMBAT_HEALTH_ESTIMATE_TYPE,
             players: game.users.filter(user => user.role < 3).map(user => ({
                 foundry_name: user.name,
                 foundry_id: user.id,
@@ -101,6 +113,7 @@ export class OronderSettingsFormApplication extends FormApplication {
             if (this.object.show_advanced && this.form.elements.show_advanced.checked) {
                 this.object.guild.combat_channel_id = Array.from(this.form.elements.combat_channel).find(c => c.selected)?.value || undefined
                 this.object.guild.combat_tracking_enabled = this.form.elements.combat_tracking_enabled.checked
+                this.object.combat_health_estimate = this.form.elements.combat_health_estimate.value
             }
             this.object.show_advanced = this.form.elements.show_advanced.checked
 
@@ -180,6 +193,8 @@ export class OronderSettingsFormApplication extends FormApplication {
         }
 
         this.bind()
+
+        await game.settings.set(MODULE_ID, COMBAT_HEALTH_ESTIMATE, this.object.combat_health_estimate)
 
         const updated_id_map = await game.settings.set(MODULE_ID, ID_MAP,
             Object.fromEntries(this.object.players.map(p => [p.foundry_id, p.discord_id]))

--- a/src/settings.mjs
+++ b/src/settings.mjs
@@ -1,4 +1,11 @@
-import {AUTH, ID_MAP, MODULE_ID, ORONDER_CONFIGURATION_FORM} from './constants.mjs'
+import {
+    AUTH,
+    COMBAT_HEALTH_ESTIMATE,
+    COMBAT_HEALTH_ESTIMATE_TYPE,
+    ID_MAP,
+    MODULE_ID,
+    ORONDER_CONFIGURATION_FORM
+} from './constants.mjs'
 import {Logger} from './util.mjs'
 import {OronderSettingsFormApplication} from './settings-form-application.mjs'
 
@@ -14,6 +21,12 @@ export const registerSettings = async () => {
         type: Object,
         config: false,
         default: {}
+    })
+    game.settings.register(MODULE_ID, COMBAT_HEALTH_ESTIMATE, {
+        scope: 'world',
+        type: Number,
+        config: false,
+        default: COMBAT_HEALTH_ESTIMATE_TYPE.none
     })
     game.settings.registerMenu(MODULE_ID, ORONDER_CONFIGURATION_FORM, {
         name: 'oronder.Oronder-Configuration',

--- a/src/sync.mjs
+++ b/src/sync.mjs
@@ -186,7 +186,7 @@ export async function del_actor(pc_id) {
 }
 
 
-const actor_to_discord_ids = actor =>
+export const actor_to_discord_ids = actor =>
     Object.entries(actor.ownership)
         .filter(([_, perm_lvl]) => perm_lvl === CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER)
         .map(([owner_id, _]) => game.settings.get(MODULE_ID, ID_MAP)[owner_id])

--- a/templates/settings-form-application.hbs
+++ b/templates/settings-form-application.hbs
@@ -209,7 +209,7 @@
             </div>
              <div class="form-group">
                 <label for="combat_health_estimate">Combat Health Estimate</label>
-                <select id="combat_health_estimate" title="Describe what All, None, Monsters only means ">
+                <select id="combat_health_estimate" title="Select whose health will be described(i.e. Healthy) rather than shown (HP 8/9).">
                     {{#each combat_health_estimate_type}}
                         <option value={{this}} {{#if
                                 (eq this ../combat_health_estimate)}}selected{{/if}}>{{@key}}</option>

--- a/templates/settings-form-application.hbs
+++ b/templates/settings-form-application.hbs
@@ -188,12 +188,11 @@
             <div class="form-group">
                 <h4>
                     <label for="combat_tracking_enabled"
-                           title="Oronder will post rolls from Discord to Foundry if a GM is logged into Foundry.">
-                        Publish Discord Rolls
+                           title="Oronder will post changes in the combat tracker to the Combat Channel configured below">
+                        Publish Combat Tracker to Discord
                     </label>
-                    <input type="checkbox" id='combat_tracking_enabled' class='control' data-action='checkbox'
-                           style='float:right'
-                        {{checked guild.combat_tracking_enabled}}>
+                    <input type="checkbox" id='combat_tracking_enabled' class='control' data-action='checkbox' 
+                        style='float:right' {{checked guild.combat_tracking_enabled}}>
                 </h4>
             </div>
             <div class="form-group">

--- a/templates/settings-form-application.hbs
+++ b/templates/settings-form-application.hbs
@@ -186,7 +186,7 @@
 
         {{#if show_advanced}}
             <div class="form-group">
-                <h3>
+                <h4>
                     <label for="combat_tracking_enabled"
                            title="(Under Development) Oronder will post rolls from Discord to Foundry if a GM is logged into Foundry.">
                         Publish Discord Rolls
@@ -194,7 +194,7 @@
                     <input type="checkbox" id='combat_tracking_enabled' class='control' data-action='checkbox'
                            style='float:right'
                         {{checked guild.combat_tracking_enabled}}>
-                </h3>
+                </h4>
             </div>
             <div class="form-group">
                 <label for="combat_channel">Combat Channel (Under Development) </label>
@@ -206,6 +206,15 @@
                     {{/each}}
                 </select>
 
+            </div>
+             <div class="form-group">
+                <label for="combat_health_estimate">Combat Health Estimate (Under Development) </label>
+                <select id="combat_health_estimate" title="Describe what All, None, Monsters only means ">
+                    {{#each combat_health_estimate_type}}
+                        <option value={{this}} {{#if
+                                (eq this ../combat_health_estimate)}}selected{{/if}}>{{@key}}</option>
+                    {{/each}}
+                </select>
             </div>
             <div class="form-group">
                 <button type="button" class='control' data-action='sync-all' {{#if buttons_disabled}}disabled{{/if}}>

--- a/templates/settings-form-application.hbs
+++ b/templates/settings-form-application.hbs
@@ -188,7 +188,7 @@
             <div class="form-group">
                 <h4>
                     <label for="combat_tracking_enabled"
-                           title="(Under Development) Oronder will post rolls from Discord to Foundry if a GM is logged into Foundry.">
+                           title="Oronder will post rolls from Discord to Foundry if a GM is logged into Foundry.">
                         Publish Discord Rolls
                     </label>
                     <input type="checkbox" id='combat_tracking_enabled' class='control' data-action='checkbox'
@@ -197,7 +197,7 @@
                 </h4>
             </div>
             <div class="form-group">
-                <label for="combat_channel">Combat Channel (Under Development) </label>
+                <label for="combat_channel">Combat Channel</label>
                 <select id="combat_channel">
                     <option value="">❌ DISABLED</option>
                     {{#each guild.forum_and_text_channels}}
@@ -208,7 +208,7 @@
 
             </div>
              <div class="form-group">
-                <label for="combat_health_estimate">Combat Health Estimate (Under Development) </label>
+                <label for="combat_health_estimate">Combat Health Estimate</label>
                 <select id="combat_health_estimate" title="Describe what All, None, Monsters only means ">
                     {{#each combat_health_estimate_type}}
                         <option value={{this}} {{#if


### PR DESCRIPTION
Adds the ability for encounters in foundry to be pushed to to a combat channel in discord.
This is great for play by posts and can take alot off the DM by automating summaries of the combat and it's participants.

My assumption is that, if the channel is disabled, nothing will be sent by the api.

Here is a test combat I used with every type of condition I could think of.
![image](https://github.com/oronder/Oronder/assets/4229134/7ef35ca0-ad92-40ea-87fa-86ec40849d75)

- Combatants will NOT show up at all, in the round summary or as a turn if they are hidden in the foundry initiative.
- Combatants will show up in the summary with the `<Hidden>` attribute if they are visible in the foundry initiative but the token is not visible.
- Combatants marked as defeated in the encounter will show up with the `<Defeated>` attribute, unless the `Skip Defeated?` option is turned on in the foundry encounter settings.
- If the combatant is linked to a discord Id, then they will be pinged in discord with the  `@NameTag`

The Combat Start and Round Start look like this:
![image](https://github.com/oronder/Oronder/assets/4229134/7c579d01-bc6d-46df-9b29-42008d0b66d0)

A Turn looks like this:
![image](https://github.com/oronder/Oronder/assets/4229134/e1ab82d4-05d4-46f4-b4a5-8d16cde656ae)

Hidden Turn:
![image](https://github.com/oronder/Oronder/assets/4229134/34478ed1-f03c-49d2-8077-fb9e43641df7)

A Player's Turn:
![image](https://github.com/oronder/Oronder/assets/4229134/480f48bc-f0e5-4343-942c-898e7a96fe9f)

Defeated Turn:
![image](https://github.com/oronder/Oronder/assets/4229134/ca077805-7f66-4a78-a09d-edca299f6817)

With Health Estimates on All:
![image](https://github.com/oronder/Oronder/assets/4229134/de734eb7-7ee2-478d-9640-884b8b6924a5)

With Health Estimates on Monsters Only:
![image](https://github.com/oronder/Oronder/assets/4229134/b0705da3-e8ed-4f37-ad8e-b3bf94fdeda1)
